### PR TITLE
tools/*/ath10k: Add support for python3 in ath10k-bencoder

### DIFF
--- a/tools/scripts/ath10k/ath10k-bdencoder
+++ b/tools/scripts/ath10k/ath10k-bdencoder
@@ -68,6 +68,8 @@ def add_ie(buf, offset, id, value):
         struct.pack_into('<B', padding, i, PADDING_MAGIC)
 
     fmt = '<2i%ds%ds' % (len(value), padding_len)
+    if not isinstance(value, bytes):
+        value = value.encode()
     struct.pack_into(fmt, buf, offset, id, len(value), value, padding.raw)
     offset = offset + TYPE_LENGTH_SIZE + len(value) + padding_len
 
@@ -255,7 +257,7 @@ class BoardContainer:
         self = BoardContainer()
 
         if not os.path.exists(filename):
-            print 'mapping file %s not found' % (filename)
+            print('mapping file %s not found' % (filename))
             return
 
         f = open(filename, 'r')
@@ -281,7 +283,7 @@ class BoardContainer:
                     # TODO: Find a better way to report problems,
                     # maybe return a list of strings? Or use an
                     # exception?
-                    print 'Warning: duplicate board name: %s' % (name.name)
+                    print('Warning: duplicate board name: %s' % (name.name))
                     return
 
                 allnames.append(name)
@@ -298,7 +300,7 @@ class BoardContainer:
             struct.pack_into('<B', padding, i, PADDING_MAGIC)
 
         fmt = '<%ds%ds' % (len(signature), pad_len)
-        struct.pack_into(fmt, buf, offset, signature, padding.raw)
+        struct.pack_into(fmt, buf, offset, signature.encode(), padding.raw)
         offset += length
 
         # make sure ATH10K_BOARD_SIGNATURE_LEN is correct
@@ -323,7 +325,7 @@ class BoardContainer:
         (signature, null) = struct.unpack_from(fmt, buf, offset)
 
         if signature != ATH10K_BOARD_SIGNATURE or null != 0:
-            print "invalid signature found in %s" % name
+            print("invalid signature found in %s" % name)
             return 1
 
         offset += ATH10K_BOARD_SIGNATURE_LEN
@@ -337,9 +339,9 @@ class BoardContainer:
             offset += TYPE_LENGTH_SIZE
 
             if offset + ie_len > buf_len:
-                print 'Error: Buffer too short (%d + %d > %d)' % (offset,
+                print('Error: Buffer too short (%d + %d > %d)' % (offset,
                                                                   ie_len,
-                                                                  buf_len)
+                                                                  buf_len))
                 return 1
 
             # FIXME: create separate ExtenderBoard() class and
@@ -362,7 +364,7 @@ class BoardContainer:
 
         self.validate()
 
-        print "board binary file '%s' is created" % name
+        print("board binary file '%s' is created" % name)
 
     def get_bin(self):
         buf = ctypes.create_string_buffer(MAX_BUF_LEN)
@@ -426,14 +428,14 @@ def cmd_extract(args):
         f.write(board.data.data)
         f.close()
 
-        print "%s created size: %d" % (filename, len(board.data.data))
+        print("%s created size: %d" % (filename, len(board.data.data)))
 
     filename = DEFAULT_JSON_FILE
     f = open(filename, 'w')
     f.write(json.dumps(mapping, indent=4))
     f.close()
 
-    print "%s created" % (filename)
+    print("%s created" % (filename))
 
 
 def cmd_info(args):
@@ -441,7 +443,7 @@ def cmd_info(args):
 
     cont = BoardContainer().open(filename)
 
-    print cont.get_summary()
+    print(cont.get_summary())
 
 
 def cmd_diff(args):
@@ -452,7 +454,7 @@ def cmd_diff(args):
         filename1 = args.diffstat[0]
         filename2 = args.diffstat[1]
 
-    print diff_boardfiles(filename1, filename2, args.diff)
+    print(diff_boardfiles(filename1, filename2, args.diff))
 
 
 def diff_boardfiles(filename1, filename2, diff):
@@ -480,10 +482,10 @@ def diff_boardfiles(filename1, filename2, diff):
             if e.returncode == 1:
                 output = e.output
             else:
-                print 'Failed to run wdiff: %d\n%s' % (e.returncode, e.output)
+                print('Failed to run wdiff: %d\n%s' % (e.returncode, e.output))
                 return 1
         except OSError as e:
-            print 'Failed to run wdiff: %s' % (e)
+            print('Failed to run wdiff: %s' % (e))
             return 1
 
         result += '%s\n' % (output)
@@ -547,7 +549,7 @@ def cmd_create(args):
 
 def cmd_add_board(args):
     if len(args.add_board) < 3:
-        print 'error: --add-board requires 3 or more arguments, only %d given' % (len(args.add_board))
+        print('error: --add-board requires 3 or more arguments, only %d given' % (len(args.add_board)))
         sys.exit(1)
 
     board_filename = args.add_board[0]
@@ -566,7 +568,7 @@ def cmd_add_board(args):
     container.add_board(new_data, new_names)
     container.write(board_filename)
 
-    print diff_boardfiles(temp_pathname, board_filename, False)
+    print(diff_boardfiles(temp_pathname, board_filename, False))
 
     os.remove(temp_pathname)
 


### PR DESCRIPTION
Now compatible with Python2 and Python3,

- Minimal changes in print add ().
- Changes in struct due to default byte strings in Python3.

Tested building board-2.bin for Dragonboard845c.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>