### PR TITLE
ath10k-bdencoder: Add option to switch to ath11k mode

### DIFF
--- a/tools/scripts/ath10k/ath10k-bdencoder
+++ b/tools/scripts/ath10k/ath10k-bdencoder
@@ -34,7 +34,9 @@ MAX_BUF_LEN = 2000000
 
 # the signature length also includes null byte and padding
 ATH10K_BOARD_SIGNATURE = b"QCA-ATH10K-BOARD"
-ATH10K_BOARD_SIGNATURE_LEN = 20
+ATH11K_BOARD_SIGNATURE = b"QCA-ATH11K-BOARD"
+BOARD_SIGNATURE = b''
+BOARD_SIGNATURE_LEN = 20
 
 PADDING_MAGIC = 0x6d
 DEFAULT_BD_API = 2
@@ -44,6 +46,7 @@ TYPE_LENGTH_SIZE = 8
 BIN_SUFFIX = '.bin'
 
 ATH10K_FIRMWARE_URL = 'https://github.com/kvalo/ath10k-firmware/commit'
+ATH11K_FIRMWARE_URL = 'https://github.com/kvalo/ath11k-firmware/commit'
 
 ATH10K_BD_IE_BOARD = 0
 ATH10K_BD_IE_BOARD_EXT = 1
@@ -311,7 +314,7 @@ class BoardContainer:
                 allnames.append(name)
 
     def _add_signature(self, buf, offset):
-        signature = ATH10K_BOARD_SIGNATURE + b'\0'
+        signature = BOARD_SIGNATURE + b'\0'
         length = len(signature)
         pad_len = padding_needed(length)
         length = length + pad_len
@@ -325,8 +328,8 @@ class BoardContainer:
         struct.pack_into(fmt, buf, offset, signature, padding.raw)
         offset += length
 
-        # make sure ATH10K_BOARD_SIGNATURE_LEN is correct
-        assert(ATH10K_BOARD_SIGNATURE_LEN == length)
+        # make sure BOARD_SIGNATURE_LEN is correct
+        assert(BOARD_SIGNATURE_LEN == length)
 
         return offset
 
@@ -343,14 +346,14 @@ class BoardContainer:
 
         offset = 0
 
-        fmt = '<%dsb' % (len(ATH10K_BOARD_SIGNATURE))
+        fmt = '<%dsb' % (len(BOARD_SIGNATURE))
         (signature, null) = struct.unpack_from(fmt, buf, offset)
 
-        if signature != ATH10K_BOARD_SIGNATURE or null != 0:
+        if signature != BOARD_SIGNATURE or null != 0:
             print("invalid signature found in %s" % name)
             return 1
 
-        offset += ATH10K_BOARD_SIGNATURE_LEN
+        offset += BOARD_SIGNATURE_LEN
 
         # looping main IEs
         while offset < buf_len:
@@ -600,6 +603,11 @@ def git_get_head_id():
 
 
 def cmd_add_mbox(args):
+    if args.mode == 10:
+        firmware_url = ATH10K_FIRMWARE_URL
+    elif args.mode == 11:
+        firmware_url = ATH10K_FIRMWARE_URL
+
     board_filename = args.add_mbox[0]
     mbox_filename = args.add_mbox[1]
 
@@ -658,8 +666,19 @@ def cmd_add_mbox(args):
         xclip(applied_msg)
 
 
+def mode_parse(v):
+    if v == 'ath10k':
+        return 10
+    elif v == 'ath11k':
+        return 11
+    else:
+        raise argparse.ArgumentTypeError('ath10k or ath11k expected.')
+
+
 def main():
-    description = '''ath10k board-N.bin files manegement tool
+    global BOARD_SIGNATURE
+
+    description = '''ath10k/ath11k board-N.bin files management tool
 
 ath10k-bdencoder is for creating (--create), listing (--info) and
 comparing (--diff, --diffstat) ath10k board-N.bin files. The
@@ -709,11 +728,19 @@ can use --extract switch to see examples from real board-N.bin files.
     parser.add_argument("-o", "--output", metavar="BOARD_FILE",
                         help='name of the output file, otherwise the default is: %s' %
                         (DEFAULT_BOARD_FILE))
+    parser.add_argument("-m", "--mode", metavar='MODE',
+                        help='select between ath10k and ath11k mode (default: ath10k)',
+                        default=10, type=mode_parse)
 
     args = parser.parse_args()
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
+
+    if args.mode == 10:
+        BOARD_SIGNATURE = ATH10K_BOARD_SIGNATURE
+    elif args.mode == 11:
+        BOARD_SIGNATURE = ATH11K_BOARD_SIGNATURE
 
     if args.create:
         return cmd_create(args)

--- a/tools/scripts/ath10k/ath10k-bdencoder
+++ b/tools/scripts/ath10k/ath10k-bdencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2015 Qualcomm Atheros, Inc.
 # Copyright (c) 2018, The Linux Foundation. All rights reserved.
@@ -33,7 +33,7 @@ import mailbox
 MAX_BUF_LEN = 2000000
 
 # the signature length also includes null byte and padding
-ATH10K_BOARD_SIGNATURE = "QCA-ATH10K-BOARD"
+ATH10K_BOARD_SIGNATURE = b"QCA-ATH10K-BOARD"
 ATH10K_BOARD_SIGNATURE_LEN = 20
 
 PADDING_MAGIC = 0x6d
@@ -83,7 +83,7 @@ def add_ie(buf, offset, id, value):
 def xclip(msg):
     p = subprocess.Popen(['xclip', '-selection', 'clipboard'],
                          stdin=subprocess.PIPE)
-    p.communicate(msg)
+    p.communicate(msg.encode())
 
 
 # to workaround annoying python feature of returning negative hex values
@@ -105,7 +105,8 @@ class BoardName():
     def parse_ie(buf, offset, length):
         self = BoardName()
         fmt = '<%ds' % length
-        (self.name, ) = struct.unpack_from(fmt, buf, offset)
+        (name, ) = struct.unpack_from(fmt, buf, offset)
+        self.name = name.decode()
 
         logging.debug('BoardName.parse_ie(): offset %d length %d self %s' %
                       (offset, length, self))
@@ -310,7 +311,7 @@ class BoardContainer:
                 allnames.append(name)
 
     def _add_signature(self, buf, offset):
-        signature = ATH10K_BOARD_SIGNATURE + '\0'
+        signature = ATH10K_BOARD_SIGNATURE + b'\0'
         length = len(signature)
         pad_len = padding_needed(length)
         length = length + pad_len
@@ -321,7 +322,7 @@ class BoardContainer:
             struct.pack_into('<B', padding, i, PADDING_MAGIC)
 
         fmt = '<%ds%ds' % (len(signature), pad_len)
-        struct.pack_into(fmt, buf, offset, signature.encode(), padding.raw)
+        struct.pack_into(fmt, buf, offset, signature, padding.raw)
         offset += length
 
         # make sure ATH10K_BOARD_SIGNATURE_LEN is correct
@@ -445,7 +446,7 @@ def cmd_extract(args):
         b['data'] = filename
         mapping.append(b)
 
-        f = open(filename, 'w')
+        f = open(filename, 'wb')
         f.write(board.data.data)
         f.close()
 
@@ -483,11 +484,11 @@ def diff_boardfiles(filename1, filename2, diff):
 
     container1 = BoardContainer().open(filename1)
     (temp1_fd, temp1_pathname) = tempfile.mkstemp()
-    os.write(temp1_fd, container1.get_summary(sort=True))
+    os.write(temp1_fd, container1.get_summary(sort=True).encode())
 
     container2 = BoardContainer().open(filename2)
     (temp2_fd, temp2_pathname) = tempfile.mkstemp()
-    os.write(temp2_fd, container2.get_summary(sort=True))
+    os.write(temp2_fd, container2.get_summary(sort=True).encode())
 
     # this function is used both with --diff and --diffstat
     if diff:
@@ -509,7 +510,7 @@ def diff_boardfiles(filename1, filename2, diff):
             print('Failed to run wdiff: %s' % (e))
             return 1
 
-        result += '%s\n' % (output)
+        result += '%s\n' % (output.decode())
 
     # create simple statistics about changes in board images
 
@@ -577,7 +578,7 @@ def cmd_add_board(args):
     new_filename = args.add_board[1]
     new_names = args.add_board[2:]
 
-    f = open(new_filename, 'r')
+    f = open(new_filename, 'rb')
     new_data = f.read()
     f.close()
 
@@ -620,15 +621,15 @@ def cmd_add_mbox(args):
             name = filename.rstrip(BIN_SUFFIX)
             board_files[name] = part.get_payload(decode=True)
 
-        print 'Found mail "%s" with %d board files' % (msg['Subject'],
-                                                       len(board_files))
+        print('Found mail "%s" with %d board files' % (msg['Subject'],
+                                                       len(board_files)))
 
         # copy the original file for diff
         (temp_fd, temp_pathname) = tempfile.mkstemp()
         shutil.copyfile(board_filename, temp_pathname)
 
         container = BoardContainer.open(board_filename)
-        for name, data in board_files.iteritems():
+        for name, data in board_files.items():
             names = [name]
             container.add_board(data, names)
 
@@ -650,9 +651,9 @@ def cmd_add_mbox(args):
 
         os.remove(temp_pathname)
 
-        print '----------------------------------------------'
-        print applied_msg
-        print '----------------------------------------------'
+        print('----------------------------------------------')
+        print(applied_msg)
+        print('----------------------------------------------')
 
         xclip(applied_msg)
 


### PR DESCRIPTION
The board-2.bin also exists on ath11k but there is no encoder available at the moment. Just use an option to change the two positions where the ath11k differs from the ath10k board-2.bin