### PR TITLE
Sync ath11k-bdencoder + ath10k-bdencoder + PY3 support

### DIFF
--- a/tools/scripts/ath10k/ath10k-bdencoder
+++ b/tools/scripts/ath10k/ath10k-bdencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2015 Qualcomm Atheros, Inc.
 # Copyright (c) 2018, The Linux Foundation. All rights reserved.
@@ -35,7 +35,7 @@ import mailbox
 MAX_BUF_LEN = 2000000
 
 # the signature length also includes null byte and padding
-ATH10K_BOARD_SIGNATURE = "QCA-ATH10K-BOARD"
+ATH10K_BOARD_SIGNATURE = b"QCA-ATH10K-BOARD"
 ATH10K_BOARD_SIGNATURE_LEN = 20
 
 PADDING_MAGIC = 0x6d
@@ -85,7 +85,7 @@ def add_ie(buf, offset, id, value):
 def xclip(msg):
     p = subprocess.Popen(['xclip', '-selection', 'clipboard'],
                          stdin=subprocess.PIPE)
-    p.communicate(msg)
+    p.communicate(msg.encode())
 
 
 # to workaround annoying python feature of returning negative hex values
@@ -107,7 +107,8 @@ class BoardName():
     def parse_ie(buf, offset, length):
         self = BoardName()
         fmt = '<%ds' % length
-        (self.name, ) = struct.unpack_from(fmt, buf, offset)
+        (name, ) = struct.unpack_from(fmt, buf, offset)
+        self.name = name.decode()
 
         logging.debug('BoardName.parse_ie(): offset %d length %d self %s' %
                       (offset, length, self))
@@ -312,7 +313,7 @@ class BoardContainer:
                 allnames.append(name)
 
     def _add_signature(self, buf, offset):
-        signature = ATH10K_BOARD_SIGNATURE + '\0'
+        signature = ATH10K_BOARD_SIGNATURE + b'\0'
         length = len(signature)
         pad_len = padding_needed(length)
         length = length + pad_len
@@ -323,7 +324,7 @@ class BoardContainer:
             struct.pack_into('<B', padding, i, PADDING_MAGIC)
 
         fmt = '<%ds%ds' % (len(signature), pad_len)
-        struct.pack_into(fmt, buf, offset, signature.encode(), padding.raw)
+        struct.pack_into(fmt, buf, offset, signature, padding.raw)
         offset += length
 
         # make sure ATH10K_BOARD_SIGNATURE_LEN is correct
@@ -447,7 +448,7 @@ def cmd_extract(args):
         b['data'] = filename
         mapping.append(b)
 
-        f = open(filename, 'w')
+        f = open(filename, 'wb')
         f.write(board.data.data)
         f.close()
 
@@ -485,11 +486,11 @@ def diff_boardfiles(filename1, filename2, diff):
 
     container1 = BoardContainer().open(filename1)
     (temp1_fd, temp1_pathname) = tempfile.mkstemp()
-    os.write(temp1_fd, container1.get_summary(sort=True))
+    os.write(temp1_fd, container1.get_summary(sort=True).encode())
 
     container2 = BoardContainer().open(filename2)
     (temp2_fd, temp2_pathname) = tempfile.mkstemp()
-    os.write(temp2_fd, container2.get_summary(sort=True))
+    os.write(temp2_fd, container2.get_summary(sort=True).encode())
 
     # this function is used both with --diff and --diffstat
     if diff:
@@ -511,7 +512,7 @@ def diff_boardfiles(filename1, filename2, diff):
             print('Failed to run wdiff: %s' % (e))
             return 1
 
-        result += '%s\n' % (output)
+        result += '%s\n' % (output.decode())
 
     # create simple statistics about changes in board images
 
@@ -579,7 +580,7 @@ def cmd_add_board(args):
     new_filename = args.add_board[1]
     new_names = args.add_board[2:]
 
-    f = open(new_filename, 'r')
+    f = open(new_filename, 'rb')
     new_data = f.read()
     f.close()
 
@@ -622,15 +623,15 @@ def cmd_add_mbox(args):
             name = filename.rstrip(BIN_SUFFIX)
             board_files[name] = part.get_payload(decode=True)
 
-        print 'Found mail "%s" with %d board files' % (msg['Subject'],
-                                                       len(board_files))
+        print('Found mail "%s" with %d board files' % (msg['Subject'],
+                                                       len(board_files)))
 
         # copy the original file for diff
         (temp_fd, temp_pathname) = tempfile.mkstemp()
         shutil.copyfile(board_filename, temp_pathname)
 
         container = BoardContainer.open(board_filename)
-        for name, data in board_files.iteritems():
+        for name, data in board_files.items():
             names = [name]
             container.add_board(data, names)
 
@@ -652,9 +653,9 @@ def cmd_add_mbox(args):
 
         os.remove(temp_pathname)
 
-        print '----------------------------------------------'
-        print applied_msg
-        print '----------------------------------------------'
+        print('----------------------------------------------')
+        print(applied_msg)
+        print('----------------------------------------------')
 
         xclip(applied_msg)
 

--- a/tools/scripts/ath10k/ath10k-bdencoder
+++ b/tools/scripts/ath10k/ath10k-bdencoder
@@ -15,6 +15,8 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
+# Run 'ath10k-bdencoder --help' to see the instructions
+#
 
 import struct
 import ctypes

--- a/tools/scripts/ath10k/ath10k-bdencoder
+++ b/tools/scripts/ath10k/ath10k-bdencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Copyright (c) 2015 Qualcomm Atheros, Inc.
 # Copyright (c) 2018, The Linux Foundation. All rights reserved.

--- a/tools/scripts/ath11k/ath11k-bdencoder
+++ b/tools/scripts/ath11k/ath11k-bdencoder
@@ -44,9 +44,13 @@ DEFAULT_JSON_FILE = 'board-%d.json' % DEFAULT_BD_API
 TYPE_LENGTH_SIZE = 8
 
 ATH11K_BD_IE_BOARD = 0
+ATH11K_BD_IE_BOARD_EXT = 1
 
 ATH11K_BD_IE_BOARD_NAME = 0
 ATH11K_BD_IE_BOARD_DATA = 1
+
+ATH11K_BD_IE_BOARD_EXT_NAME = 0
+ATH11K_BD_IE_BOARD_EXT_DATA = 1
 
 
 def padding_needed(len):
@@ -98,8 +102,12 @@ class BoardName():
 
         return self
 
-    def add_to_buf(self, buf, offset):
-        return add_ie(buf, offset, ATH11K_BD_IE_BOARD_NAME, str(self.name))
+    def add_to_buf(self, ebdf, buf, offset):
+        ie_id = ATH11K_BD_IE_BOARD_NAME
+        if ebdf:
+            ie_id = ATH11K_BD_IE_BOARD_EXT_NAME
+
+        return add_ie(buf, offset, ie_id, str(self.name))
 
     def __eq__(self, other):
         return self.name == other.name
@@ -126,8 +134,12 @@ class BoardData():
 
         return self
 
-    def add_to_buf(self, buf, offset):
-        return add_ie(buf, offset, ATH11K_BD_IE_BOARD_DATA, self.data)
+    def add_to_buf(self, ebdf, buf, offset):
+        ie_id = ATH11K_BD_IE_BOARD_DATA
+        if ebdf:
+            ie_id = ATH11K_BD_IE_BOARD_EXT_DATA
+
+        return add_ie(buf, offset, ie_id, self.data)
 
     def __repr__(self):
         return self.__str__()
@@ -165,9 +177,12 @@ class Board():
             offset += TYPE_LENGTH_SIZE
             length -= TYPE_LENGTH_SIZE
 
-            if ie_id == ATH11K_BD_IE_BOARD_NAME:
+            # FIXME: create separate ExtenderBoard() class so that we
+            # don't need these "or" hacks here. Maybe add a common
+            # abstract class to avoid code duplication?
+            if ie_id == ATH11K_BD_IE_BOARD_NAME or ie_id == ATH11K_BD_IE_BOARD_EXT_NAME:
                 self.names.append(BoardName.parse_ie(buf, offset, ie_len))
-            elif ie_id == ATH11K_BD_IE_BOARD_DATA:
+            elif ie_id == ATH11K_BD_IE_BOARD_DATA or ie_id == ATH11K_BD_IE_BOARD_EXT_DATA:
                 self.data = BoardData.parse_ie(buf, offset, ie_len)
 
             offset += ie_len + padding_needed(ie_len)
@@ -181,14 +196,19 @@ class Board():
 
         offset += TYPE_LENGTH_SIZE
 
-        for name in self.names:
-            offset = name.add_to_buf(buf, offset)
+        ie_id = ATH11K_BD_IE_BOARD
 
-        offset = self.data.add_to_buf(buf, offset)
+        if self.ebdf:
+            ie_id = ATH11K_BD_IE_BOARD_EXT
+
+        for name in self.names:
+            offset = name.add_to_buf(self.ebdf, buf, offset)
+
+        offset = self.data.add_to_buf(self.ebdf, buf, offset)
 
         # write ie header as now we know the full length
         ie_len = offset - ie_offset - TYPE_LENGTH_SIZE
-        struct.pack_into('<2i', buf, ie_offset, ATH11K_BD_IE_BOARD, ie_len)
+        struct.pack_into('<2i', buf, ie_offset, ie_id, ie_len)
 
         return offset
 
@@ -212,16 +232,21 @@ class Board():
     def __init__(self):
         self.data = None
         self.names = []
+        self.ebdf = False
 
 
 class BoardContainer:
 
     def add_board(self, data, names):
         boardnames = []
+        ebdf = False
         for name in names:
+            if "bmi-eboard-id" in name:
+                ebdf = True
             boardnames.append(BoardName(name))
 
         board = Board()
+        board.ebdf = ebdf
         board.data = BoardData(data)
         board.names = boardnames
 
@@ -319,7 +344,9 @@ class BoardContainer:
                                                                   buf_len)
                 return 1
 
-            if ie_id == ATH11K_BD_IE_BOARD:
+            # FIXME: create separate ExtenderBoard() class and
+            # self.extender_boards list
+            if ie_id == ATH11K_BD_IE_BOARD or ie_id == ATH11K_BD_IE_BOARD_EXT:
                 self.boards.append(Board.parse_ie(buf, offset, ie_len))
 
             offset += ie_len + padding_needed(ie_len)

--- a/tools/scripts/ath11k/ath11k-bdencoder
+++ b/tools/scripts/ath11k/ath11k-bdencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2015-2017 Qualcomm Atheros, Inc.
 # Copyright (c) 2018-2019, The Linux Foundation. All rights reserved.
@@ -35,7 +35,7 @@ import mailbox
 MAX_BUF_LEN = 2000000
 
 # the signature length also includes null byte and padding
-ATH11K_BOARD_SIGNATURE = "QCA-ATH11K-BOARD"
+ATH11K_BOARD_SIGNATURE = b"QCA-ATH11K-BOARD"
 ATH11K_BOARD_SIGNATURE_LEN = 20
 
 PADDING_MAGIC = 0x6d
@@ -74,6 +74,8 @@ def add_ie(buf, offset, id, value):
         struct.pack_into('<B', padding, i, PADDING_MAGIC)
 
     fmt = '<2i%ds%ds' % (len(value), padding_len)
+    if not isinstance(value, bytes):
+        value = value.encode()
     struct.pack_into(fmt, buf, offset, id, len(value), value, padding.raw)
     offset = offset + TYPE_LENGTH_SIZE + len(value) + padding_len
 
@@ -83,7 +85,7 @@ def add_ie(buf, offset, id, value):
 def xclip(msg):
     p = subprocess.Popen(['xclip', '-selection', 'clipboard'],
                          stdin=subprocess.PIPE)
-    p.communicate(msg)
+    p.communicate(msg.encode())
 
 
 # to workaround annoying python feature of returning negative hex values
@@ -105,7 +107,8 @@ class BoardName():
     def parse_ie(buf, offset, length):
         self = BoardName()
         fmt = '<%ds' % length
-        (self.name, ) = struct.unpack_from(fmt, buf, offset)
+        (name, ) = struct.unpack_from(fmt, buf, offset)
+        self.name = name.decode()
 
         logging.debug('BoardName.parse_ie(): offset %d length %d self %s' %
                       (offset, length, self))
@@ -278,7 +281,7 @@ class BoardContainer:
         self = BoardContainer()
 
         if not os.path.exists(filename):
-            print 'mapping file %s not found' % (filename)
+            print('mapping file %s not found' % (filename))
             return
 
         f = open(filename, 'r')
@@ -304,13 +307,13 @@ class BoardContainer:
                     # TODO: Find a better way to report problems,
                     # maybe return a list of strings? Or use an
                     # exception?
-                    print 'Warning: duplicate board name: %s' % (name.name)
+                    print('Warning: duplicate board name: %s' % (name.name))
                     return
 
                 allnames.append(name)
 
     def _add_signature(self, buf, offset):
-        signature = ATH11K_BOARD_SIGNATURE + '\0'
+        signature = ATH11K_BOARD_SIGNATURE + b'\0'
         length = len(signature)
         pad_len = padding_needed(length)
         length = length + pad_len
@@ -346,7 +349,7 @@ class BoardContainer:
         (signature, null) = struct.unpack_from(fmt, buf, offset)
 
         if signature != ATH11K_BOARD_SIGNATURE or null != 0:
-            print "invalid signature found in %s" % name
+            print("invalid signature found in %s" % name)
             return 1
 
         offset += ATH11K_BOARD_SIGNATURE_LEN
@@ -360,9 +363,9 @@ class BoardContainer:
             offset += TYPE_LENGTH_SIZE
 
             if offset + ie_len > buf_len:
-                print 'Error: Buffer too short (%d + %d > %d)' % (offset,
+                print('Error: Buffer too short (%d + %d > %d)' % (offset,
                                                                   ie_len,
-                                                                  buf_len)
+                                                                  buf_len))
                 return 1
 
             # FIXME: create separate ExtenderBoard() class and
@@ -385,7 +388,7 @@ class BoardContainer:
 
         self.validate()
 
-        print "board binary file '%s' is created" % name
+        print("board binary file '%s' is created" % name)
 
     def get_bin(self):
         buf = ctypes.create_string_buffer(MAX_BUF_LEN)
@@ -445,18 +448,18 @@ def cmd_extract(args):
         b['data'] = filename
         mapping.append(b)
 
-        f = open(filename, 'w')
+        f = open(filename, 'wb')
         f.write(board.data.data)
         f.close()
 
-        print "%s created size: %d" % (filename, len(board.data.data))
+        print("%s created size: %d" % (filename, len(board.data.data)))
 
     filename = DEFAULT_JSON_FILE
     f = open(filename, 'w')
     f.write(json.dumps(mapping, indent=4))
     f.close()
 
-    print "%s created" % (filename)
+    print("%s created" % (filename))
 
 
 def cmd_info(args):
@@ -464,7 +467,7 @@ def cmd_info(args):
 
     cont = BoardContainer().open(filename)
 
-    print cont.get_summary()
+    print(cont.get_summary())
 
 
 def cmd_diff(args):
@@ -475,7 +478,7 @@ def cmd_diff(args):
         filename1 = args.diffstat[0]
         filename2 = args.diffstat[1]
 
-    print diff_boardfiles(filename1, filename2, args.diff)
+    print(diff_boardfiles(filename1, filename2, args.diff))
 
 
 def diff_boardfiles(filename1, filename2, diff):
@@ -483,11 +486,11 @@ def diff_boardfiles(filename1, filename2, diff):
 
     container1 = BoardContainer().open(filename1)
     (temp1_fd, temp1_pathname) = tempfile.mkstemp()
-    os.write(temp1_fd, container1.get_summary(sort=True))
+    os.write(temp1_fd, container1.get_summary(sort=True).encode())
 
     container2 = BoardContainer().open(filename2)
     (temp2_fd, temp2_pathname) = tempfile.mkstemp()
-    os.write(temp2_fd, container2.get_summary(sort=True))
+    os.write(temp2_fd, container2.get_summary(sort=True).encode())
 
     # this function is used both with --diff and --diffstat
     if diff:
@@ -503,13 +506,13 @@ def diff_boardfiles(filename1, filename2, diff):
             if e.returncode == 1:
                 output = e.output
             else:
-                print 'Failed to run wdiff: %d\n%s' % (e.returncode, e.output)
+                print('Failed to run wdiff: %d\n%s' % (e.returncode, e.output))
                 return 1
         except OSError as e:
-            print 'Failed to run wdiff: %s' % (e)
+            print('Failed to run wdiff: %s' % (e))
             return 1
 
-        result += '%s\n' % (output)
+        result += '%s\n' % (output.decode())
 
     # create simple statistics about changes in board images
 
@@ -570,14 +573,14 @@ def cmd_create(args):
 
 def cmd_add_board(args):
     if len(args.add_board) < 3:
-        print 'error: --add-board requires 3 or more arguments, only %d given' % (len(args.add_board))
+        print('error: --add-board requires 3 or more arguments, only %d given' % (len(args.add_board)))
         sys.exit(1)
 
     board_filename = args.add_board[0]
     new_filename = args.add_board[1]
     new_names = args.add_board[2:]
 
-    f = open(new_filename, 'r')
+    f = open(new_filename, 'rb')
     new_data = f.read()
     f.close()
 
@@ -589,7 +592,7 @@ def cmd_add_board(args):
     container.add_board(new_data, new_names)
     container.write(board_filename)
 
-    print diff_boardfiles(temp_pathname, board_filename, False)
+    print(diff_boardfiles(temp_pathname, board_filename, False))
 
     os.remove(temp_pathname)
 
@@ -620,15 +623,15 @@ def cmd_add_mbox(args):
             name = filename.rstrip(BIN_SUFFIX)
             board_files[name] = part.get_payload(decode=True)
 
-        print 'Found mail "%s" with %d board files' % (msg['Subject'],
-                                                       len(board_files))
+        print('Found mail "%s" with %d board files' % (msg['Subject'],
+                                                       len(board_files)))
 
         # copy the original file for diff
         (temp_fd, temp_pathname) = tempfile.mkstemp()
         shutil.copyfile(board_filename, temp_pathname)
 
         container = BoardContainer.open(board_filename)
-        for name, data in board_files.iteritems():
+        for name, data in board_files.items():
             names = [name]
             container.add_board(data, names)
 
@@ -650,9 +653,9 @@ def cmd_add_mbox(args):
 
         os.remove(temp_pathname)
 
-        print '----------------------------------------------'
-        print applied_msg
-        print '----------------------------------------------'
+        print('----------------------------------------------')
+        print(applied_msg)
+        print('----------------------------------------------')
 
         xclip(applied_msg)
 

--- a/tools/scripts/ath11k/ath11k-bdencoder
+++ b/tools/scripts/ath11k/ath11k-bdencoder
@@ -30,6 +30,7 @@ import subprocess
 import logging
 import sys
 import shutil
+import mailbox
 
 MAX_BUF_LEN = 2000000
 
@@ -42,6 +43,9 @@ DEFAULT_BD_API = 2
 DEFAULT_BOARD_FILE = 'board-%d.bin' % DEFAULT_BD_API
 DEFAULT_JSON_FILE = 'board-%d.json' % DEFAULT_BD_API
 TYPE_LENGTH_SIZE = 8
+BIN_SUFFIX = '.bin'
+
+ATH11K_FIRMWARE_URL = 'https://github.com/kvalo/ath11k-firmware/commit'
 
 ATH11K_BD_IE_BOARD = 0
 ATH11K_BD_IE_BOARD_EXT = 1
@@ -74,6 +78,12 @@ def add_ie(buf, offset, id, value):
     offset = offset + TYPE_LENGTH_SIZE + len(value) + padding_len
 
     return offset
+
+
+def xclip(msg):
+    p = subprocess.Popen(['xclip', '-selection', 'clipboard'],
+                         stdin=subprocess.PIPE)
+    p.communicate(msg)
 
 
 # to workaround annoying python feature of returning negative hex values
@@ -237,10 +247,21 @@ class Board():
 
 class BoardContainer:
 
+    def find_board(self, name):
+        for board in self.boards:
+            for boardname in board.names:
+                if name == boardname.name:
+                    return board
+
     def add_board(self, data, names):
         boardnames = []
         ebdf = False
+
         for name in names:
+            b = self.find_board(name)
+            if b:
+                self.boards.remove(b)
+
             if "bmi-eboard-id" in name:
                 ebdf = True
             boardnames.append(BoardName(name))
@@ -573,6 +594,69 @@ def cmd_add_board(args):
     os.remove(temp_pathname)
 
 
+def git_get_head_id():
+    return subprocess.check_output(['git', 'log', '--format=format:%H', '-1'])
+
+
+def cmd_add_mbox(args):
+    board_filename = args.add_mbox[0]
+    mbox_filename = args.add_mbox[1]
+
+    mbox = mailbox.mbox(mbox_filename)
+
+    for msg in mbox:
+        board_files = {}
+
+        for part in msg.walk():
+            filename = part.get_filename()
+
+            if not filename:
+                # not an attachment
+                continue
+
+            if not filename.endswith(BIN_SUFFIX):
+                continue
+
+            name = filename.rstrip(BIN_SUFFIX)
+            board_files[name] = part.get_payload(decode=True)
+
+        print 'Found mail "%s" with %d board files' % (msg['Subject'],
+                                                       len(board_files))
+
+        # copy the original file for diff
+        (temp_fd, temp_pathname) = tempfile.mkstemp()
+        shutil.copyfile(board_filename, temp_pathname)
+
+        container = BoardContainer.open(board_filename)
+        for name, data in board_files.iteritems():
+            names = [name]
+            container.add_board(data, names)
+
+        container.write(board_filename)
+
+        applied_msg = ''
+
+        if args.commit:
+            cmd = ['git', 'commit', '--quiet', '-m', msg['Subject'], board_filename]
+            subprocess.check_call(cmd)
+
+            applied_msg += 'Thanks, added to %s:\n\n' % (board_filename)
+
+        applied_msg += diff_boardfiles(temp_pathname, board_filename, False)
+        applied_msg += '\n\n'
+
+        if args.commit:
+            applied_msg += '%s/%s\n\n' % (ATH11K_FIRMWARE_URL, git_get_head_id())
+
+        os.remove(temp_pathname)
+
+        print '----------------------------------------------'
+        print applied_msg
+        print '----------------------------------------------'
+
+        xclip(applied_msg)
+
+
 def main():
     description = '''ath11k board-N.bin files manegement tool
 
@@ -614,6 +698,11 @@ can use --extract switch to see examples from real board-N.bin files.
     cmd_group.add_argument('-a', '--add-board', metavar='NAME', nargs='+',
                            help='add a board file to an existing board-N.bin, first argument is the filename of board-N.bin to add to, second is the filename board file (board.bin) to add and then followed by one or more arguments are names used in board-N.bin')
 
+    cmd_group.add_argument('-A', '--add-mbox', metavar='FILENAME', nargs=2,
+                           help='FIXME')
+
+    parser.add_argument('-C', '--commit', action='store_true',
+                        help='commit changes to a git repository')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='enable verbose (debug) messages')
     parser.add_argument("-o", "--output", metavar="BOARD_FILE",
@@ -637,6 +726,8 @@ can use --extract switch to see examples from real board-N.bin files.
         return cmd_diff(args)
     elif args.add_board:
         return cmd_add_board(args)
+    elif args.add_mbox:
+        return cmd_add_mbox(args)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The ath11k-bdencoder was basically a copy of 6c34812fc71785c321fb20767360bfc9ff465948:tools/scripts/ath10k/ath10k-bdencoder send through

    sed -e 's/ath11k/ath10k/g' -e 's/ATH11K/ATH10K/g'

So add the missing changes from ath10k-bdencoder after 6c34812fc71785c321fb20767360bfc9ff465948 to ath11k-bdencoder.

---

The py3 stuff is the version from PR #6 (so it should include the fix for the conflict during the merge which was forced-pushed away by @kvalo ).