### PR TITLE
Enlarge the hardcoded MAX_BUF_LEN

### DIFF
--- a/tools/scripts/ath11k/ath11k-bdencoder
+++ b/tools/scripts/ath11k/ath11k-bdencoder
@@ -31,7 +31,7 @@ import logging
 import sys
 import shutil
 
-MAX_BUF_LEN = 2000000
+MAX_BUF_LEN = 10000000
 
 # the signature length also includes null byte and padding
 ATH11K_BOARD_SIGNATURE = b"QCA-ATH11K-BOARD"


### PR DESCRIPTION
Fixes `struct.error: pack_into requires a buffer of at least 2044368 bytes for packing 59972 bytes at offset 1984396 (actual buffer size is 2000000)`

MAX_BUF_LEN=2000000 is too small for the latest `WCN6855/hw2.0/board-2.bin` that was newly added in [September](https://github.com/kvalo/ath11k-firmware/commit/23a624bb642a6a56138f39a5f872fcfa3496e883).