### PR TITLE
scripts: use /usr/bin/env python3

### DIFF
--- a/tools/scripts/ath10k/ath10k-bdencoder
+++ b/tools/scripts/ath10k/ath10k-bdencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2015 Qualcomm Atheros, Inc.
 # Copyright (c) 2018, The Linux Foundation. All rights reserved.

--- a/tools/scripts/ath10k/ath10k-fw-repo
+++ b/tools/scripts/ath10k/ath10k-fw-repo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2016 Qualcomm Atheros, Inc.
 # Copyright (c) 2018, The Linux Foundation. All rights reserved.

--- a/tools/scripts/ath10k/ath10k-fwencoder
+++ b/tools/scripts/ath10k/ath10k-fwencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2012-2015 Qualcomm Atheros, Inc.
 #

--- a/tools/scripts/ath11k/ath11k-fw-repo
+++ b/tools/scripts/ath11k/ath11k-fw-repo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2016 Qualcomm Atheros, Inc.
 # Copyright (c) 2018,2020 The Linux Foundation. All rights reserved.

--- a/tools/scripts/ath11k/ath11k-fwencoder
+++ b/tools/scripts/ath11k/ath11k-fwencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2012-2015 Qualcomm Atheros, Inc.
 # Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.

--- a/tools/scripts/ath12k/ath12k-fw-repo
+++ b/tools/scripts/ath12k/ath12k-fw-repo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2016 Qualcomm Atheros, Inc.
 # Copyright (c) 2018,2020 The Linux Foundation. All rights reserved.

--- a/tools/scripts/ath12k/ath12k-fwencoder
+++ b/tools/scripts/ath12k/ath12k-fwencoder
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2023 Qualcomm Innovation Center, Inc. All rights reserved
 # Copyright (c) 2018-2019, The Linux Foundation. All rights reserved.

--- a/tools/scripts/ath9k/read-powers
+++ b/tools/scripts/ath9k/read-powers
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2010 Atheros Communications Inc.
 #


### PR DESCRIPTION
Using #!/usr/bin/env python3 instead of #!/usr/bin/python3 in the shebang line of a script is generally considered better practice for portability and flexibility.

* env uses the user's PATH environment variable to locate python3
* Using env avoids hardcoding the path, making your script more portable.
* Works well with virtual environments: